### PR TITLE
Update Art team description from OSVF to Embodied AI Foundation

### DIFF
--- a/_team/artists/01-xavier.md
+++ b/_team/artists/01-xavier.md
@@ -2,7 +2,7 @@
 name_: Xavier Godina
 description: Art Lead
 portrait: img/team/artists/xavier_godina.png
-from: CVC & OSVF
+from: CVC & Embodied AI Foundation
 page: https://www.artstation.com/fresquet
 github:
 ---

--- a/_team/artists/02-daniel.md
+++ b/_team/artists/02-daniel.md
@@ -2,7 +2,7 @@
 name_: Daniel Navas
 description: Art developer
 portrait: img/team/artists/daniel_navas.png
-from: CVC & OSVF
+from: CVC & Embodied AI Foundation
 page: https://www.artstation.com/dnavas
 github:
 ---

--- a/_team/artists/03-mario.md
+++ b/_team/artists/03-mario.md
@@ -2,7 +2,7 @@
 name_: Mario González
 description: Art developer
 portrait: img/team/artists/mario_gonzález.jpg
-from: CVC & OSVF
+from: CVC & Embodied AI Foundation
 page: https://www.artstation.com/mariogs
 github:
 ---

--- a/_team/artists/04-marcos.md
+++ b/_team/artists/04-marcos.md
@@ -2,7 +2,7 @@
 name_: Marcos Delgado
 description: Art developer
 portrait: img/team/artists/marcos_delgado.png
-from: CVC & OSVF
+from: CVC & Embodied AI Foundation
 page: https://www.artstation.com/madecu
 github:
 ---


### PR DESCRIPTION
# Updated art team members

I have update the descriptions of the art team from OSVF to Embodied AI foundation because I forgot to do so when I updated the engineering team.