### PR TITLE
Documentation URL change

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -18,7 +18,7 @@
           <a class="nav-link" href="{{"/posts" | relative_url }}">Blog</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" target="_blank" href="http://carla.readthedocs.io/en/latest/">Documentation</a>
+          <a class="nav-link" target="_blank" href="https://carla.readthedocs.io">Documentation</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" target="_blank" href="https://github.com/carla-simulator/carla">GitHub</a>


### PR DESCRIPTION
Changed documentation URL so it goes to the base doc URL instead of /en/latest/. This is so it redirects to the correct version of the docs